### PR TITLE
Make tests pass on newer click (>=7.1.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "pypy"
 
 install:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,9 +35,9 @@ def test_basic_functionality_with_group(runner):
     result = runner.invoke(cli, ["barr"])
     assert result.output == (
         "Usage: cli [OPTIONS] COMMAND [ARGS]...\n"
-        'Try "cli --help" for help.\n'
+        "Try 'cli --help' for help.\n"
         "\n"
-        "Error: No such command \"barr\".\n\n"
+        "Error: No such command 'barr'.\n\n"
         "Did you mean one of these?\n"
         "    barrr\n"
         "    bar\n"
@@ -69,9 +69,9 @@ def test_basic_functionality_with_commandcollection(runner):
     result = runner.invoke(cli, ["barr"])
     assert result.output == (
         "Usage: root [OPTIONS] COMMAND [ARGS]...\n"
-        'Try "root --help" for help.\n'
+        "Try 'root --help' for help.\n"
         "\n"
-        "Error: No such command \"barr\".\n\n"
+        "Error: No such command 'barr'.\n\n"
         "Did you mean one of these?\n"
         "    barrr\n"
         "    bar\n"
@@ -99,9 +99,9 @@ def test_cutoff_factor(runner):
     result = runner.invoke(cli, ["barr"])
     assert result.output == (
         "Usage: cli [OPTIONS] COMMAND [ARGS]...\n"
-        'Try "cli --help" for help.\n'
+        "Try 'cli --help' for help.\n"
         "\n"
-        "Error: No such command \"barr\".\n"
+        "Error: No such command 'barr'.\n"
     )
 
 
@@ -130,9 +130,9 @@ def test_max_suggetions(runner):
     result = runner.invoke(cli, ["barr"])
     assert result.output == (
         "Usage: cli [OPTIONS] COMMAND [ARGS]...\n"
-        'Try "cli --help" for help.\n'
+        "Try 'cli --help' for help.\n"
         "\n"
-        "Error: No such command \"barr\".\n\n"
+        "Error: No such command 'barr'.\n\n"
         "Did you mean one of these?\n"
         "    barrr\n"
         "    baarr\n"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy
+envlist = py27,py35,py36,py37,py38,pypy
 
 [testenv]
 passenv = LANG


### PR DESCRIPTION
Used downstream in Fedora: https://src.fedoraproject.org/rpms/python-click-didyoumean/blob/master/f/0001-Fix-tests-some-more.patch