### PR TITLE
Remove upper bound from Python version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/click-contrib/click-didyoumean"
 readme = "README.rst"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = ">=3.6.2"
 click = ">=7"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
I've removed the upper bound from Python's version specifier, i.e. I've replaced the version specifier `^` by `>=`.

Capping the Python version (e.g. `<4`) is a bad practice.

* https://github.com/pypa/packaging.python.org/pull/850
* https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special
* https://discuss.python.org/t/requires-python-upper-limits/12663

When using Poetry in a project that depends on `click-didyoumean`, the upper bound gets enforced also on that project, so the "disease" spreads across the ecosystem.