### PR TITLE
Fix dependency manifest and CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,13 +4,12 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.python-version == '3.6' && 'ubuntu-20.04' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ click = ">=7"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
 black = "^21.9b0"
-isort = "^5.9.3"
+isort = {version = "^5.9.3", python = "<4"}
 flake8 = "^3.9.2"
 mypy = "^0.910"
 


### PR DESCRIPTION
I've fixed the dependency manifest to install `isort` only for Python <4. The reason is this: Since this project requires Python 3.6+, only dependencies that also require Python 3.6+ or lower can be resolved. The last version of `isort` that still required only Python 3.6+ used an upper bound (`<4`) on the Python version specifier, so `isort` cannot be resolved anymore. To work around this problem, I've added the Python version upper bound only to `isort`.

I've also fixed the CI config to use Ubuntu 20.04 when testing against Python 3.6 because that's the last Ubuntu version supporting Python 3.6. CI checks for all other Python versions run against the latest available Ubuntu version.

These changes should restore the installation with Poetry and CI. :crossed_fingers: