### PR TITLE
Drop support for Python 3.6/3.7 and extend test matrix to Python 3.11/3.12

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    runs-on: ${{ matrix.python-version == '3.6' && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v1
@@ -35,7 +35,7 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags')
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - run: pip install -U pip poetry
       - name: Publish package
         if: startsWith(github.event.ref, 'refs/tags')

--- a/examples/naval.py
+++ b/examples/naval.py
@@ -17,57 +17,59 @@ def ship():
     """Manages ships."""
 
 
-@ship.command('new')
-@click.argument('name')
+@ship.command("new")
+@click.argument("name")
 def ship_new(name):
     """Creates a new ship."""
-    click.echo('Created ship %s' % name)
+    click.echo("Created ship %s" % name)
 
 
-@ship.command('move')
-@click.argument('ship')
-@click.argument('x', type=float)
-@click.argument('y', type=float)
-@click.option('--speed', metavar='KN', default=10,
-              help='Speed in knots.')
+@ship.command("move")
+@click.argument("ship")
+@click.argument("x", type=float)
+@click.argument("y", type=float)
+@click.option("--speed", metavar="KN", default=10, help="Speed in knots.")
 def ship_move(ship, x, y, speed):
     """Moves SHIP to the new location X,Y."""
-    click.echo('Moving ship %s to %s,%s with speed %s' % (ship, x, y, speed))
+    click.echo("Moving ship %s to %s,%s with speed %s" % (ship, x, y, speed))
 
 
-@ship.command('shoot')
-@click.argument('ship')
-@click.argument('x', type=float)
-@click.argument('y', type=float)
+@ship.command("shoot")
+@click.argument("ship")
+@click.argument("x", type=float)
+@click.argument("y", type=float)
 def ship_shoot(ship, x, y):
     """Makes SHIP fire to X,Y."""
-    click.echo('Ship %s fires to %s,%s' % (ship, x, y))
+    click.echo("Ship %s fires to %s,%s" % (ship, x, y))
 
 
-@cli.group('mine', cls=DYMGroup)
+@cli.group("mine", cls=DYMGroup)
 def mine():
     """Manages mines."""
 
 
-@mine.command('set')
-@click.argument('x', type=float)
-@click.argument('y', type=float)
-@click.option('ty', '--moored', flag_value='moored',
-              default=True,
-              help='Moored (anchored) mine. Default.')
-@click.option('ty', '--drifting', flag_value='drifting',
-              help='Drifting mine.')
+@mine.command("set")
+@click.argument("x", type=float)
+@click.argument("y", type=float)
+@click.option(
+    "ty",
+    "--moored",
+    flag_value="moored",
+    default=True,
+    help="Moored (anchored) mine. Default.",
+)
+@click.option("ty", "--drifting", flag_value="drifting", help="Drifting mine.")
 def mine_set(x, y, ty):
     """Sets a mine at a specific coordinate."""
-    click.echo('Set %s mine at %s,%s' % (ty, x, y))
+    click.echo("Set %s mine at %s,%s" % (ty, x, y))
 
 
-@mine.command('remove')
-@click.argument('x', type=float)
-@click.argument('y', type=float)
+@mine.command("remove")
+@click.argument("x", type=float)
+@click.argument("y", type=float)
 def mine_remove(x, y):
     """Removes a mine at a specific coordinate."""
-    click.echo('Removed mine at %s,%s' % (x, y))
+    click.echo("Removed mine at %s,%s" % (x, y))
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ repository = "https://github.com/click-contrib/click-didyoumean"
 readme = "README.rst"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2"
+python = ">=3.8"
 click = ">=7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
-black = "^21.9b0"
-isort = {version = "^5.9.3", python = "<4"}
-flake8 = "^3.9.2"
+black = "^24.3.0"
+isort = "^5.9.3"
+flake8 = {version = "^7.0.0", python = ">=3.8.1"}
 mypy = "^0.910"
 
 [build-system]


### PR DESCRIPTION
I've dropped support for all EOL versions of Python (3.6 and 3.7) and extended the CI test matrix to run tests against Python 3.11 and 3.12.