### PR TITLE
Use Ruff instead of Black/isort/Flake8

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,8 +20,8 @@ jobs:
       - run: pip install -U pip poetry
       - run: poetry config virtualenvs.create false
       - run: poetry install
-      - run: flake8 --max-line-length 88 src/ tests/
-      - run: black --diff --check src/ tests/
+      - run: ruff check src/ tests/
+      - run: ruff format --diff --check src/ tests/
       - run: mypy src/ tests/
       - run: pytest
 

--- a/examples/naval.py
+++ b/examples/naval.py
@@ -31,7 +31,7 @@ def ship_new(name):
 @click.option("--speed", metavar="KN", default=10, help="Speed in knots.")
 def ship_move(ship, x, y, speed):
     """Moves SHIP to the new location X,Y."""
-    click.echo("Moving ship %s to %s,%s with speed %s" % (ship, x, y, speed))
+    click.echo(f"Moving ship {ship} to {x},{y} with speed {speed}")
 
 
 @ship.command("shoot")
@@ -40,7 +40,7 @@ def ship_move(ship, x, y, speed):
 @click.argument("y", type=float)
 def ship_shoot(ship, x, y):
     """Makes SHIP fire to X,Y."""
-    click.echo("Ship %s fires to %s,%s" % (ship, x, y))
+    click.echo(f"Ship {ship} fires to {x},{y}")
 
 
 @cli.group("mine", cls=DYMGroup)
@@ -61,7 +61,7 @@ def mine():
 @click.option("ty", "--drifting", flag_value="drifting", help="Drifting mine.")
 def mine_set(x, y, ty):
     """Sets a mine at a specific coordinate."""
-    click.echo("Set %s mine at %s,%s" % (ty, x, y))
+    click.echo(f"Set {ty} mine at {x},{y}")
 
 
 @mine.command("remove")
@@ -69,7 +69,7 @@ def mine_set(x, y, ty):
 @click.argument("y", type=float)
 def mine_remove(x, y):
     """Removes a mine at a specific coordinate."""
-    click.echo("Removed mine at %s,%s" % (x, y))
+    click.echo(f"Removed mine at {x},{y}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,23 @@ click = ">=7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
-black = "^24.3.0"
-isort = "^5.9.3"
-flake8 = {version = "^7.0.0", python = ">=3.8.1"}
 mypy = "^0.910"
+ruff = "0.3.4"
+
+[tool.ruff]
+src = ["src"]
+target-version = "py38"
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["ANN101", "COM812", "D", "FA", "ISC001"]
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
+
+[tool.ruff.lint.per-file-ignores]
+"examples/**" = ["ANN", "D", "INP001"]
+"tests/**" = ["ANN", "D", "INP001", "S101"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/click_didyoumean/__init__.py
+++ b/src/click_didyoumean/__init__.py
@@ -16,10 +16,10 @@ class DYMMixin:
     a certain command is not registered.
     """
 
-    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:  # noqa: ANN401
         self.max_suggestions = kwargs.pop("max_suggestions", 3)
         self.cutoff = kwargs.pop("cutoff", 0.5)
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(*args, **kwargs)  # type: ignore[call-arg]
 
     def resolve_command(
         self, ctx: click.Context, args: typing.List[str]
@@ -32,13 +32,13 @@ class DYMMixin:
         to the raised exception message.
         """
         try:
-            return super(DYMMixin, self).resolve_command(ctx, args)  # type: ignore
+            return super().resolve_command(ctx, args)  # type: ignore[misc]
         except click.exceptions.UsageError as error:
             error_msg = str(error)
             original_cmd_name = click.utils.make_str(args[0])
             matches = difflib.get_close_matches(
                 original_cmd_name,
-                self.list_commands(ctx),  # type: ignore
+                self.list_commands(ctx),  # type: ignore[attr-defined]
                 self.max_suggestions,
                 self.cutoff,
             )
@@ -47,7 +47,7 @@ class DYMMixin:
                 error_msg += "\n\n"
                 error_msg += f"Did you mean one of these?\n    {fmt_matches}"
 
-            raise click.exceptions.UsageError(error_msg, error.ctx)
+            raise click.exceptions.UsageError(error_msg, error.ctx) from error
 
 
 class DYMGroup(DYMMixin, click.Group):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,8 +5,8 @@ from click.testing import CliRunner
 from click_didyoumean import DYMCommandCollection, DYMGroup
 
 
-@pytest.fixture(scope="function")
-def runner(request):
+@pytest.fixture()
+def runner():
     return CliRunner()
 
 


### PR DESCRIPTION
I've replaced Black, isort, and Flake8 by Ruff.

Ruff's config enables all linters except those that (a) would require manual changes to the code (which we can enable and resolve separately) or (b) [conflict with Ruff's formatter](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules). Regarding (b), I exclude the minimum set of rules such that the following statement in the docs holds:

> When an incompatible lint rule or setting is enabled, `ruff format` will emit a warning. If your `ruff format` is free of warnings, you're good to go!

I went for pinning [Ruff's version](https://docs.astral.sh/ruff/versioning/#version-changes) because every release _may_ change Ruff's expectations, so IMO we should update Ruff deliberately and resolve errors in the process. WDYT?

Closes #15 as a side-effect of removing Black.