### PR TITLE
Enable Poetry's virtual env in CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,12 +18,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -U pip poetry
-      - run: poetry config virtualenvs.create false
       - run: poetry install
-      - run: ruff check src/ tests/
-      - run: ruff format --diff --check src/ tests/
-      - run: mypy src/ tests/
-      - run: pytest
+      - run: poetry run ruff check src/ tests/
+      - run: poetry run ruff format --diff --check src/ tests/
+      - run: poetry run mypy src/ tests/
+      - run: poetry run pytest
 
   cd:
     needs: [ci]


### PR DESCRIPTION
I've removed the setting to disable Poetry's virtual envs in CI checks. Since Poetry is installed through pip into the global environment, it's better to let Poetry install the dependencies into its managed virtual env, so that there can be no conflict between Poetry's own dependencies and those installed via Poetry.